### PR TITLE
Alha config

### DIFF
--- a/src/com/hms_networks/americas/sc/config/ConfigFile.java
+++ b/src/com/hms_networks/americas/sc/config/ConfigFile.java
@@ -98,4 +98,16 @@ public abstract class ConfigFile {
     File configFile = new File(getConfigFilePath());
     return configFile.isFile();
   }
+
+
+
+  /**
+   * Loads the default configuration contents into memory and writes to the file system.
+   *
+   * @throws ConfigFileWriteException if unable to write to file
+   */
+  public void loadAndSaveDefaultConfiguration() throws ConfigFileWriteException {
+    configurationObject = getDefaultConfigurationObject();
+    save();
+  }
 }

--- a/src/com/hms_networks/americas/sc/config/ConfigFile.java
+++ b/src/com/hms_networks/americas/sc/config/ConfigFile.java
@@ -6,6 +6,7 @@ import com.hms_networks.americas.sc.config.exceptions.ConfigFileWriteException;
 import com.hms_networks.americas.sc.json.JSONException;
 import com.hms_networks.americas.sc.json.JSONObject;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -86,5 +87,15 @@ public abstract class ConfigFile {
           "Unable to write configuration to disk. Invalid file path or configuration object specified.",
           e);
     }
+  }
+
+  /**
+   * Gets a boolean representing the presence of the configuration file in the file system.
+   *
+   * @return true if configuration file exists on in the file system
+   */
+  public boolean fileExists() {
+    File configFile = new File(getConfigFilePath());
+    return configFile.isFile();
   }
 }


### PR DESCRIPTION
The addition of these methods allow connectors to automatically create a default configuration file on disk. This will reduce the number of files required for the connector to function, since the configuration file will not be required to be copied by the end-user.